### PR TITLE
Deprecate and package unusable tests and

### DIFF
--- a/src/test/java/deprecated_tests/AdminMenuScreenTest.java
+++ b/src/test/java/deprecated_tests/AdminMenuScreenTest.java
@@ -1,8 +1,10 @@
+package deprecated_tests;
+
 import screens.AdminMainMenu;
 
 import javax.swing.*;
 
-
+@Deprecated
 public class AdminMenuScreenTest {
     public static void main(String[] args){
 

--- a/src/test/java/deprecated_tests/CardTest.java
+++ b/src/test/java/deprecated_tests/CardTest.java
@@ -1,7 +1,10 @@
+package deprecated_tests;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Deprecated
 class CardTest {
 
     @Test

--- a/src/test/java/deprecated_tests/ComputerDecisionTest.java
+++ b/src/test/java/deprecated_tests/ComputerDecisionTest.java
@@ -1,3 +1,5 @@
+package deprecated_tests;
+
 import org.junit.jupiter.api.Test;
 import static org.junit.Assert.*;
 

--- a/src/test/java/deprecated_tests/DeckTest.java
+++ b/src/test/java/deprecated_tests/DeckTest.java
@@ -1,7 +1,10 @@
+package deprecated_tests;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Deprecated
 class DeckTest {
 
     @Test

--- a/src/test/java/deprecated_tests/GameScreenTest.java
+++ b/src/test/java/deprecated_tests/GameScreenTest.java
@@ -1,3 +1,5 @@
+package deprecated_tests;
+
 import game_entities.*;
 import game_use_case.*;
 import screens.*;
@@ -5,6 +7,7 @@ import screens.*;
 import javax.swing.*;
 import java.awt.*;
 
+@Deprecated
 public class GameScreenTest {
 
     public static void main(String[] args){

--- a/src/test/java/deprecated_tests/LoginScreenTest.java
+++ b/src/test/java/deprecated_tests/LoginScreenTest.java
@@ -1,7 +1,10 @@
+package deprecated_tests;
+
 import screens.LoginScreen;
 
 import javax.swing.*;
 
+@Deprecated
 public class LoginScreenTest {
 
     public static void main(String[] args){


### PR DESCRIPTION
All tests that are not being used have been deprecated. These classes include:
- AdminMenuScreenTest
- CardTest
- ComputerDecisionTest
- DeckTest
- GameScreenTest
- LoginScreenTest